### PR TITLE
use clock_gettime(CLOCK_MONOTONIC) instead of time()

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -75,7 +75,8 @@ my %WriteMakefile = (
 		'Params::Util'      => '0',
 		'parent'            => '0',
 		'Statistics::CaseResampling' => '0.06',
-		'Time::HiRes'       => '0',
+		# Time::HiRes::clock_gettime() for Windows was implemented in 1.9764
+		'Time::HiRes'       => ($^O eq 'MSWin32' ? '1.9764': '0'),
 		},
 
 	'META_MERGE' => {

--- a/lib/Dumbbench/Instance/Cmd.pm
+++ b/lib/Dumbbench/Instance/Cmd.pm
@@ -2,7 +2,7 @@ package Dumbbench::Instance::Cmd;
 use strict;
 use warnings;
 use Carp ();
-use Time::HiRes ();
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 
 use Dumbbench::Instance;
 use parent 'Dumbbench::Instance';
@@ -93,15 +93,15 @@ sub single_run {
   my ($start, $end);
   if ($self->use_shell) {
     my $cmd = join ' ', @cmd;
-    $start = Time::HiRes::time();
+    $start = clock_gettime(CLOCK_MONOTONIC);
     system($cmd);
-    $end = Time::HiRes::time();
+    $end = clock_gettime(CLOCK_MONOTONIC);
   }
   else {
     my $cmd = $cmd[0];
-    $start = Time::HiRes::time();
+    $start = clock_gettime(CLOCK_MONOTONIC);
     system({$cmd} @cmd);
-    $end = Time::HiRes::time();
+    $end = clock_gettime(CLOCK_MONOTONIC);
   }
 
   my $duration = $end-$start;

--- a/lib/Dumbbench/Instance/PerlEval.pm
+++ b/lib/Dumbbench/Instance/PerlEval.pm
@@ -13,7 +13,7 @@ package Dumbbench::Instance::PerlEval;
 use strict;
 use warnings;
 use Carp ();
-use Time::HiRes ();
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 
 use Dumbbench::Instance;
 use parent 'Dumbbench::Instance';
@@ -111,9 +111,9 @@ sub _run {
     #my $start;
     #my $tbase = Time::HiRes::time();
     #while ( ($start = Time::HiRes::time()) <= $tbase+1.e-15 ) {} # wait for clock tick. See discussion in Benchmark.pm comments
-    my $start = Time::HiRes::time();
+    my $start = clock_gettime(CLOCK_MONOTONIC);
     Dumbbench::Instance::PerlEval::_Lexical::doeval($n, \$code);
-    my $end = Time::HiRes::time();
+    my $end = clock_gettime(CLOCK_MONOTONIC);
 
     $duration = $end-$start;
     if ($duration > TOO_SMALL) {

--- a/lib/Dumbbench/Instance/PerlSub.pm
+++ b/lib/Dumbbench/Instance/PerlSub.pm
@@ -14,7 +14,7 @@ package Dumbbench::Instance::PerlSub;
 use strict;
 use warnings;
 use Carp ();
-use Time::HiRes ();
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 
 use Dumbbench::Instance;
 use parent 'Dumbbench::Instance';
@@ -112,9 +112,9 @@ sub _run {
     #my $start;
     #my $tbase = Time::HiRes::time();
     #while ( ($start = Time::HiRes::time()) <= $tbase+1.e-15 ) {} # wait for clock tick. See discussion in Benchmark.pm comments
-    my $start = Time::HiRes::time();
+    my $start = clock_gettime(CLOCK_MONOTONIC);
     Dumbbench::Instance::PerlSub::_Lexical::runsub($n, $code);
-    my $end = Time::HiRes::time();
+    my $end = clock_gettime(CLOCK_MONOTONIC);
 
     $duration = $end-$start;
     if ($duration > TOO_SMALL) {


### PR DESCRIPTION
CLOCK_MONOTONIC is more suitable for measuring elapsed time. Its main
advantage is that it can't go backwards.