### PR TITLE
Doc/instances naming

### DIFF
--- a/lib/Dumbbench.pm
+++ b/lib/Dumbbench.pm
@@ -313,9 +313,9 @@ As a module:
     initial_runs         => 20,    # the higher the more reliable
   );
   $bench->add_instances(
-    Dumbbench::Instance::Cmd->new(command => [qw(perl -e 'something')]),
-    Dumbbench::Instance::PerlEval->new(code => 'for(1..1e7){something}'),
-    Dumbbench::Instance::PerlSub->new(code => sub {for(1..1e7){something}}),
+    Dumbbench::Instance::Cmd->new(name => 'fork', command => [qw(perl -e 'something')]),
+    Dumbbench::Instance::PerlEval->new(name => 'eval', code => 'for(1..1e7){something}'),
+    Dumbbench::Instance::PerlSub->new(name => 'sub', code => sub {for(1..1e7){something}}),
   );
   # (Note: Comparing the run of externals commands with
   #  evals/subs probably isn't reliable)
@@ -374,12 +374,28 @@ as argument. Each of those is one I<benchmark>, really.
 They are run in sequence and reported separately.
 
 Right now, there are the following C<Dumbbench::Instance> implementations:
-L<Dumbbench::Instance::Cmd> for running/benchmarking external commands,
-L<Dumbbench::Instance::PerlEval> for running/benchmarking
-Perl code in this same process using C<eval>,
-and
-L<Dumbbench::Instance::PerlSub> for running/benchmarking
-Perl code in this same process using a subroutine reference.
+
+=over
+
+=item *
+
+L<Dumbbench::Instance::Cmd> for running/benchmarking external commands.
+
+=item *
+
+L<Dumbbench::Instance::PerlEval> for running/benchmarking Perl code in this same
+process using C<eval>.
+
+=item *
+
+L<Dumbbench::Instance::PerlSub> for running/benchmarking Perl code in this same
+process using a subroutine reference.
+
+=back
+
+You probably want to pass a C<name> parameter to the C<new> method of each
+L<Dumbbench::Instance> subclasses. That will make clearer in the C<report>
+output which line corresponds to which instance passed.
 
 =head2 run
 

--- a/lib/Dumbbench.pm
+++ b/lib/Dumbbench.pm
@@ -532,17 +532,41 @@ robust estimates of the run time of meaningless benchmarks instead.
 
 =head1 SEE ALSO
 
-L<Dumbbench::Instance>,
-L<Dumbbench::Instance::Cmd>,
-L<Dumbbench::Instance::PerlEval>,
-L<Dumbbench::Instance::PerlSub>,
+=over
+
+=item *
+
+L<Dumbbench::Instance>
+
+=item *
+
+L<Dumbbench::Instance::Cmd>
+
+=item *
+
+L<Dumbbench::Instance::PerlEval>
+
+=item *
+
+L<Dumbbench::Instance::PerlSub>
+
+=item *
+
 L<Dumbbench::Result>
+
+=item *
 
 L<Benchmark>
 
+=item *
+
 L<Number::WithError> does the Gaussian error propagation.
 
+=item *
+
 L<http://en.wikipedia.org/wiki/Median_absolute_deviation>
+
+=back
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Just improving the documentation with examples adding `name` to [Dumbbench::Instance](https://metacpan.org/pod/Dumbbench::Instance) sub classes, in order to get a report with properly lines identification.

Also improved the Pod format.

By some reason, the extended tests are failing in my machine, but that also happens with release 0.503 as well.

```
alceu@temp:~/Projects/dumbbench$ prove -l xt
xt/at_000_eval_vs_sub.t ....... # 
# 1.4961e-01 +/- 1.7e-04
# 1.5569e-01 +/- 1.6e-04
xt/at_000_eval_vs_sub.t ....... 1/2 
#   Failed test at xt/at_000_eval_vs_sub.t line 39.
#     '0.14995'
#         >=
#     '0.15537'
Can't call method "Run" on an undefined value at xt/at_000_eval_vs_sub.t line 64.
# Looks like your test exited with 2 just after 2.
xt/at_000_eval_vs_sub.t ....... Dubious, test returned 2 (wstat 512, 0x200)
Failed 1/2 subtests 
xt/at_000_external_vs_eval.t .. # 
# eval: Ran 23 iterations (3 outliers).
# eval: Rounded run time per iteration (seconds): 1.4575e-01 +/- 1.6e-04 (0.1%)
# cmd: Ran 20 iterations (0 outliers).
# cmd: Rounded run time per iteration (seconds): 1.5006e-01 +/- 7.6e-04 (0.5%)
xt/at_000_external_vs_eval.t .. 1/2 
#   Failed test at xt/at_000_external_vs_eval.t line 39.
#     '0.14607'
#         >=
#     '0.14854'
# Looks like you failed 1 test of 2.
xt/at_000_external_vs_eval.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests 
xt/changes.t .................. ok   

Test Summary Report
-------------------
xt/at_000_eval_vs_sub.t     (Wstat: 512 (exited 2) Tests: 2 Failed: 1)
  Failed test:  1
  Non-zero exit status: 2
xt/at_000_external_vs_eval.t (Wstat: 256 (exited 1) Tests: 2 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=3, Tests=8, 15 wallclock secs ( 0.03 usr  0.00 sys + 14.18 cusr  0.24 csys = 14.45 CPU)
Result: FAIL
```
